### PR TITLE
Bump support library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@ allprojects {
 
     ext {
         compileSdkVersion = 27
-        buildToolsVersion = '27.0.2'
+        buildToolsVersion = '27.0.3'
 
         minSdkVersion = 14
         targetSdkVersion = 27
-        versionCode = 6
-        versionName = '1.0.5'
-        supportLibraryVersion = '27.0.2'
+        versionCode = 7
+        versionName = '1.0.6'
+        supportLibraryVersion = '27.1.0'
     }
 }
 


### PR DESCRIPTION
The purpose is to make the library working with projects that already include the Android support library in version 27.1.0.